### PR TITLE
Generate documentation for an API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,5 +79,6 @@ gem 'blueprinter'
 gem 'cancancan'
 gem 'devise'
 gem 'jwt'
+gem 'rswag'
 gem 'rubocop', '>= 1.0', '< 2.0'
 gem 'rubocop-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,8 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     jwt (2.3.0)
     loofah (2.18.0)
       crass (~> 1.0.2)
@@ -219,6 +221,19 @@ GEM
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
     rspec-support (3.11.0)
+    rswag (2.5.1)
+      rswag-api (= 2.5.1)
+      rswag-specs (= 2.5.1)
+      rswag-ui (= 2.5.1)
+    rswag-api (2.5.1)
+      railties (>= 3.1, < 7.1)
+    rswag-specs (2.5.1)
+      activesupport (>= 3.1, < 7.1)
+      json-schema (~> 2.2)
+      railties (>= 3.1, < 7.1)
+    rswag-ui (2.5.1)
+      actionpack (>= 3.1, < 7.1)
+      railties (>= 3.1, < 7.1)
     rubocop (1.29.1)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -298,6 +313,7 @@ DEPENDENCIES
   rails (~> 7.0.2, >= 7.0.2.4)
   rails-controller-testing
   rspec-rails (~> 6.0.0.rc1)
+  rswag
   rubocop (>= 1.0, < 2.0)
   rubocop-rails
   selenium-webdriver

--- a/config/initializers/rswag-ui.rb
+++ b/config/initializers/rswag-ui.rb
@@ -1,0 +1,14 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the swagger-ui
+  # The first parameter is the path (absolute or relative to the UI host) to the corresponding
+  # endpoint and the second is a title that will be displayed in the document selector
+  # NOTE: If you're using rspec-api to expose Swagger files (under swagger_root) as JSON or YAML endpoints,
+  # then the list below should correspond to the relative paths for those endpoints
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lamda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,20 +1,17 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   devise_for :users
   root 'users#index'
-
-  # Create an API endpoint to list all posts for a user.
-  # Create an API endpoint to list all comments for a user's post.
-  # Create an API endpoint to add a comment to a post. The owner of the comment is the user that makes it.
-  # Add authentication to your API endpoints.
-  # Your API endpoints should receive JSON and respond JSON as well.
 
   namespace :api , defaults: { format: :json } do
     namespace :v1 do
       post 'users/sign_up' => 'users#register'
       post 'users/sign_in' => 'users#login'
       get 'posts' => 'posts#index'
+      post 'posts/create' => 'posts#create'
       get 'comments' => 'comments#index'
       post 'comments/create' => 'comments#create'
     end

--- a/spec/integration/comments_spec.rb
+++ b/spec/integration/comments_spec.rb
@@ -1,0 +1,51 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/comments', type: :request do
+  path '/api/v1/comments' do
+    # You'll want to customize the parameter types...
+    parameter name: 'X-Token', in: :header, type: :string
+
+    get('list comments') do
+      tags 'Comments'
+      response(200, 'successful') do
+        let(:'X-Token') { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/comments/create' do
+    # You'll want to customize the parameter types...
+    parameter name: 'X-Token', in: :header, type: :string
+
+    post 'Create a comment' do
+      tags 'Comments'
+      consumes 'application/json'
+      parameter name: :comment, in: :body, schema: {
+        type: :object,
+        properties: {
+          text: { type: :string }
+        },
+        required: ['text']
+      }
+
+      response '201', 'comment created' do
+        let(:comment) { { text: 'foo' } }
+        run_test!
+      end
+
+      response '422', 'invalid request' do
+        let(:comment) { { text: 'foo' } }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/integration/posts_spec.rb
+++ b/spec/integration/posts_spec.rb
@@ -1,0 +1,52 @@
+require 'swagger_helper'
+
+RSpec.describe 'api/v1/posts', type: :request do
+  path '/api/v1/posts' do
+    # You'll want to customize the parameter types...
+    parameter name: 'X-Token', in: :header, type: :string
+
+    get('list posts') do
+      tags 'posts'
+      response(200, 'successful') do
+        let(:'X-Token') { '123' }
+
+        after do |example|
+          example.metadata[:response][:content] = {
+            'application/json' => {
+              example: JSON.parse(response.body, symbolize_names: true)
+            }
+          }
+        end
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/posts/create' do
+    # You'll want to customize the parameter types...
+    parameter name: 'X-Token', in: :header, type: :string
+
+    post 'Create a post' do
+      tags 'posts'
+      consumes 'application/json'
+      parameter name: :post, in: :body, schema: {
+        type: :object,
+        properties: {
+          title: { type: :string },
+          text: { type: :string }
+        },
+        required: %w[title text]
+      }
+
+      response '201', 'post created' do
+        let(:post) { { title: 'foo', text: 'bar' } }
+        run_test!
+      end
+
+      response '422', 'invalid request' do
+        let(:post) { { title: 'foo', text: 'bar' } }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/integration/users_spec.rb
+++ b/spec/integration/users_spec.rb
@@ -1,0 +1,58 @@
+require 'swagger_helper'
+
+RSpec.describe 'api//v1/users', type: :request do
+  path '/api/v1/users/sign_up' do
+    # You'll want to customize the parameter types...
+
+    post 'Sign up' do
+      tags 'users'
+      consumes 'application/json'
+      parameter name: :user, in: :body, schema: {
+        type: :object,
+        properties: {
+          name: { type: :string },
+          email: { type: :string },
+          password: { type: :string }
+        },
+        required: %w[name email password]
+      }
+
+      response '201', 'Sign up successfull' do
+        let(:user) { { name: 'Tom', email: 'email@example.com', text: '123456' } }
+        run_test!
+      end
+
+      response '422', 'invalid request' do
+        let(:user) { { name: 'Tom', email: 'email@example.com', text: '123456' } }
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/users/sign_in' do
+    # You'll want to customize the parameter types...
+
+    post 'Sign in' do
+      tags 'users'
+      consumes 'application/json'
+      parameter name: :user, in: :body, schema: {
+        type: :object,
+        properties: {
+          email: { type: :string },
+          password: { type: :string }
+        },
+        required: %w[email password]
+      }
+
+      response '201', 'Sign in successfull' do
+        let(:user) { { email: 'email@example.com', text: '123456' } }
+        run_test!
+      end
+
+      response '422', 'invalid request' do
+        let(:user) { { email: 'email@example.com', text: '123456' } }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/requests/api/my_spec.rb
+++ b/spec/requests/api/my_spec.rb
@@ -1,0 +1,4 @@
+# require 'swagger_helper'
+
+# RSpec.describe 'api/my', type: :request do
+# end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.swagger_root = Rails.root.join('swagger').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under swagger_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a swagger_doc tag to the
+  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
+  config.swagger_docs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'www.example.com'
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The swagger_docs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.swagger_format = :yaml
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,143 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/api/v1/comments":
+    parameters:
+    - name: X-Token
+      in: header
+      schema:
+        type: string
+    get:
+      summary: list comments
+      tags:
+      - Comments
+      responses:
+        '200':
+          description: successful
+  "/api/v1/comments/create":
+    parameters:
+    - name: X-Token
+      in: header
+      schema:
+        type: string
+    post:
+      summary: Create a comment
+      tags:
+      - Comments
+      parameters: []
+      responses:
+        '201':
+          description: comment created
+        '422':
+          description: invalid request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+              required:
+              - text
+  "/api/v1/posts":
+    parameters:
+    - name: X-Token
+      in: header
+      schema:
+        type: string
+    get:
+      summary: list posts
+      tags:
+      - posts
+      responses:
+        '200':
+          description: successful
+  "/api/v1/posts/create":
+    parameters:
+    - name: X-Token
+      in: header
+      schema:
+        type: string
+    post:
+      summary: Create a post
+      tags:
+      - posts
+      parameters: []
+      responses:
+        '201':
+          description: post created
+        '422':
+          description: invalid request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                text:
+                  type: string
+              required:
+              - title
+              - text
+  "/api/v1/users/sign_up":
+    post:
+      summary: Sign up
+      tags:
+      - users
+      parameters: []
+      responses:
+        '201':
+          description: Sign up successfull
+        '422':
+          description: invalid request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                password:
+                  type: string
+              required:
+              - name
+              - email
+              - password
+  "/api/v1/users/sign_in":
+    post:
+      summary: Sign in
+      tags:
+      - users
+      parameters: []
+      responses:
+        '201':
+          description: Sign in successfull
+        '422':
+          description: invalid request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                password:
+                  type: string
+              required:
+              - email
+              - password
+servers:
+- url: https://{defaultHost}
+  variables:
+    defaultHost:
+      default: www.example.com


### PR DESCRIPTION
Created API documentation for the following endpoints:

- /api/v1/users/sign_up
- /api/v1/users/sign_in
- /api/v1/posts
- /api/v1/posts/create
- /api/v1/comments
- /api/v1/comments/create